### PR TITLE
Update types.js Drops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "p4-dandoridesktop",
-            "version": "1.7.8",
+            "version": "1.7.9",
             "license": "MIT",
             "dependencies": {
                 "@emotion/react": "^11.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "p4-dandoridesktop",
-    "version": "1.7.8",
+    "version": "1.7.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "p4-dandoridesktop",
     "productName": "p4-dandoridesktop",
-    "version": "1.7.8",
+    "version": "1.7.9",
     "description": "A Pikmin 4 Editor",
     "main": ".webpack/main",
     "icon": "src/images/icon/icon.ico",

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -845,14 +845,14 @@ export const defaultCreatureAI = {
     vel: {
         X: 0.0,
         Y: 0.0,
-        Z: 0.0
+        Z: 350.0
     },
     randVel: {
-        X: 0.0,
-        Y: 0.0,
-        Z: 0.0
+        X: 25.0,
+        Y: 25.0,
+        Z: 25.0
     },
-    dropOption: 6,
+    dropOption: 1,
     bOverrideInitLocation: false,
     overrideInitLocation: {
         X: 0.0,


### PR DESCRIPTION
Changed Vel to 350 and randVel to 25, to make default drops work like traditional pikmin drops (they fly out of the creature in a random direction) dropOption is now 1 by default, meaning each item will randomly pick between all 3 based on % weights